### PR TITLE
Add support python 3.13

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-*
+          CIBW_BUILD: cp39-* cp310-* cp311-* cp312-* cp313-*
           CIBW_ARCHS_WINDOWS: auto
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_ARCHS_LINUX: auto

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Cython",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Dear ts2vg team, thanks for the nice package.

I saw that installing the ts2vg package was not possible on my 3.13 python install, please see the following error:


```sh
Collecting ts2vg
  Downloading ts2vg-1.2.4.tar.gz (774 kB)
     ------------------------------------- 775.0/775.0 kB 14.1 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  Getting requirements to build wheel did not run successfully.
  exit code: 1
  
  [36 lines of output]
  Traceback (most recent call last):
    File "C:\hostedtoolcache\windows\Python\3.13.1\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 389, in <module>
      main()
      ~~~~^^
    File "C:\hostedtoolcache\windows\Python\3.13.1\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 373, in main
      json_out["return_val"] = hook(**hook_input["kwargs"])
                               ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\hostedtoolcache\windows\Python\3.13.1\x64\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py", line 143, in get_requires_for_build_wheel
      return hook(config_settings)
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\setuptools\build_meta.py", line 334, in get_requires_for_build_wheel
      return self._get_build_requires(config_settings, requirements=[])
             ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\setuptools\build_meta.py", line 304, in _get_build_requires
      self.run_setup()
      ~~~~~~~~~~~~~~^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\setuptools\build_meta.py", line 320, in run_setup
      exec(code, locals())
      ~~~~^^^^^^^^^^^^^^^^
    File "<string>", line 45, in <module>
    File "<string>", line 39, in main
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\Cython\Build\Dependencies.py", line 1010, in cythonize
      module_list, module_metadata = create_extension_list(
                                     ~~~~~~~~~~~~~~~~~~~~~^
          module_list,
          ^^^^^^^^^^^^
      ...<4 lines>...
          language=language,
          ^^^^^^^^^^^^^^^^^^
          aliases=aliases)
          ^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\Cython\Build\Dependencies.py", line 845, in create_extension_list
      for file in nonempty(sorted(extended_iglob(filepattern)), "'%s' doesn't match any files" % filepattern):
                  ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "C:\Users\runneradmin\AppData\Local\Temp\pip-build-env-75mgcoi7\overlay\Lib\site-packages\Cython\Build\Dependencies.py", line 117, in nonempty
      raise ValueError(error_msg)
  ValueError: 'ts2vg/graph/_base.pyx' doesn't match any files
  [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

Getting requirements to build wheel did not run successfully.
exit code: 1

See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

I realised that it may just be because the package is not building the package completely for 3.13. I installed the package manually from source and ran the pytest to check if everything is working. See results here:

```sh
(313) PS J:\git\ts2vg> pytest
============================================================================================= test session starts ==============================================================================================
platform win32 -- Python 3.13.2, pytest-8.3.4, pluggy-1.5.0
rootdir: J:\git\ts2vg
configfile: pyproject.toml
collected 206 items

tests\test_horizontal.py ...................................                                                                                                                                              [ 16%]
tests\test_horizontal_penetrable.py .........................................................                                                                                                             [ 44%]
tests\test_natural.py ....................................................                                                                                                                                [ 69%]
tests\test_natural_penetrable.py .........................................................                                                                                                                [ 97%]
tests\test_parametric.py .....                                                                                                                                                                            [100%]

============================================================================================= 206 passed in 17.58s =============================================================================================

```


With this, I took a look at the previous commits when a version change occurred and applied the same logic to add 3.13 to the main pypi package. 

Please let me know if there is anything else I can do to make the upgrade easy for you. Thanks in advance.

Best,

Johannes